### PR TITLE
feat(ai-dev): update workspace app and parameter icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,37 @@ To add a new AI plugin option (optional enhancement):
 - Wrap npm installs with `sudo` for global packages
 - Use `|| echo` in startup_script for non-fatal error handling
 
+## Icon Guidelines
+
+### Using Coder Built-in Icons
+
+Coder provides 137+ built-in icons at `/icon/`. Always prefer these over custom icons to avoid licensing concerns and ensure consistency.
+
+**Icon Reference:**
+
+| Icon | Path | Use For |
+|------|------|---------|
+| Python | `/icon/python.svg` | Python stacks |
+| Go | `/icon/go.svg` | Go stack |
+| VS Code | `/icon/code.svg` | VS Code, generic code, "None" options |
+| Claude | `/icon/claude.svg` | Claude Code, Oh-My-ClaudeCode |
+| OpenCode | `/icon/opencode.svg` | OpenCode, Oh-My-OpenCode |
+| OpenAI | `/icon/openai.svg` | Codex |
+| GitHub | `/icon/github.svg` | Copilot |
+| Gemini | `/icon/gemini.svg` | Gemini CLI |
+| Terminal | `/icon/terminal.svg` | Generic CLI tools (fallback) |
+
+**Browse all available icons:** https://github.com/coder/coder/tree/main/site/static/icon
+
+### Adding Icons to Templates
+
+When adding new `coder_parameter` options or `coder_app` resources:
+
+1. **Check Coder's built-in icons first** - Most common tools/languages are already available
+2. **Use recognizable brand icons** - Match the tool/service being represented
+3. **Fallback to generic icons** - Use `/icon/terminal.svg` or `/icon/code.svg` if no specific icon exists
+4. **Be consistent** - Use the same icon for related resources (e.g., OpenCode app and Oh-My-OpenCode plugin)
+
 ## Important Constraints
 
 ### Parameter Mutability

--- a/templates/ai-dev/main.tf
+++ b/templates/ai-dev/main.tf
@@ -65,7 +65,7 @@ data "coder_parameter" "ai_plugin" {
   option {
     name  = "Oh-My-OpenCode"
     value = "oh-my-opencode"
-    icon  = "/icon/terminal.svg"
+    icon  = "/icon/opencode.svg"
   }
 }
 
@@ -231,7 +231,7 @@ resource "coder_app" "opencode" {
   agent_id     = coder_agent.main.id
   slug         = "opencode"
   display_name = "OpenCode"
-  icon         = "/icon/terminal.svg"
+  icon         = "/icon/opencode.svg"
   command      = "cd /home/coder && opencode"
 }
 
@@ -241,7 +241,7 @@ resource "coder_app" "codex" {
   agent_id     = coder_agent.main.id
   slug         = "codex"
   display_name = "OpenAI Codex"
-  icon         = "/icon/terminal.svg"
+  icon         = "/icon/openai.svg"
   command      = "cd /home/coder && codex"
 }
 
@@ -250,7 +250,7 @@ resource "coder_app" "copilot" {
   agent_id     = coder_agent.main.id
   slug         = "copilot"
   display_name = "GitHub Copilot"
-  icon         = "/icon/terminal.svg"
+  icon         = "/icon/github.svg"
   command      = "cd /home/coder && copilot"
 }
 
@@ -259,6 +259,6 @@ resource "coder_app" "gemini" {
   agent_id     = coder_agent.main.id
   slug         = "gemini"
   display_name = "Google Gemini"
-  icon         = "/icon/terminal.svg"
+  icon         = "/icon/gemini.svg"
   command      = "cd /home/coder && gemini"
 }


### PR DESCRIPTION
## Summary
- Updates `coder_app` icons for OpenCode, Codex (OpenAI), Copilot (GitHub), and Gemini to use recognizable brand logos from Coder's built-in icon set.
- Updates `oh-my-opencode` parameter option icon to use the OpenCode logo.
- Adds "Icon Guidelines" section to `CLAUDE.md` to ensure consistent icon usage in the future.

Closes #5