### PR TITLE
ci: simplify pre-release notes to only include PR ID and title

### DIFF
--- a/.github/workflows/package-templates.yml
+++ b/.github/workflows/package-templates.yml
@@ -88,15 +88,9 @@ jobs:
           tag_name: ${{ steps.prerelease_version.outputs.tag }}
           name: Pre-release ${{ steps.prerelease_version.outputs.tag }}
           body: |
-            ## Pre-release from PR #${{ github.event.pull_request.number }}
-            
-            **Branch:** ${{ github.head_ref }}
-            **PR Title:** ${{ github.event.pull_request.title }}
-            
+            ## Pre-release from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+
             This is an automated pre-release for testing. Do not use in production.
-            
-            ### Changes
-            ${{ github.event.pull_request.body }}
           files: dist/*.zip
           prerelease: true
           target_commitish: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

- Simplified the pre-release body in the `package-templates.yml` workflow to only include the PR number and title
- Removed the branch name, separate PR title line, and the "Changes" section that included the full PR description body
- Consolidated the PR identifier and title into a single heading line for cleaner release notes

## Why

Pre-release notes were including the full PR description (`github.event.pull_request.body`), which added unnecessary verbosity to draft releases created from PRs. Since pre-releases are for testing purposes only, the release notes should be minimal — just enough to identify which PR triggered the build.

## Implementation Details

**Changed file:** `.github/workflows/package-templates.yml`

The pre-release body was reduced from:
```
## Pre-release from PR #N
**Branch:** ...
**PR Title:** ...
This is an automated pre-release for testing. Do not use in production.
### Changes
<full PR description>
```

To:
```
## Pre-release from PR #N: <PR title>
This is an automated pre-release for testing. Do not use in production.
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)