### PR TITLE
fix(ai-dev): use Claude Code plugin system for oh-my-claudecode

### DIFF
--- a/templates/ai-dev/scripts/agents/oh-my-claudecode.sh
+++ b/templates/ai-dev/scripts/agents/oh-my-claudecode.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # oh-my-claudecode.sh - Install Oh-My-ClaudeCode plugin
-# Requires: Claude Code (from base-ai-tools.sh), Node.js and npm (from common-deps.sh)
+# Requires: Claude Code (from base-ai-tools.sh)
 set -e
 
-# Install oh-my-claudecode plugin (Claude Code already installed by base-ai-tools.sh)
-sudo npm install -g oh-my-claudecode
+# Install oh-my-claudecode plugin via Claude Code's plugin system
+# This uses the undocumented CLI commands for non-interactive installation
+# Reference: https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# Add the oh-my-claudecode marketplace (idempotent - updates if already present)
+sudo -u coder claude mpa https://github.com/Yeachan-Heo/oh-my-claudecode || echo "Failed to add oh-my-claudecode marketplace (non-fatal)"
+
+# Install the plugin from the marketplace
+sudo -u coder claude pla oh-my-claudecode || echo "Failed to install oh-my-claudecode plugin (non-fatal)"
+
+echo "oh-my-claudecode plugin installed - run /oh-my-claudecode:omc-setup in Claude Code to complete setup"


### PR DESCRIPTION
## Summary
- Fixed oh-my-claudecode installation by using Claude Code's plugin CLI commands instead of npm
- The npm package `oh-my-claudecode` does not exist on the registry (was returning E404)
- Now uses `claude mpa` to add marketplace and `claude pla` to install plugin

## Problem
The installation was failing with:
```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/oh-my-claudecode - Not found
```

## Solution
oh-my-claudecode is distributed as a Claude Code plugin, not an npm package. Updated script to use the correct installation method:
```bash
claude mpa https://github.com/Yeachan-Heo/oh-my-claudecode  # Add marketplace
claude pla oh-my-claudecode  # Install plugin
```

Fixes #17

## Test plan
- [ ] Create a new workspace with oh-my-claudecode plugin enabled
- [ ] Verify no npm E404 errors during startup
- [ ] Verify plugin is available in Claude Code (`/oh-my-claudecode:help`)

🤖 Generated with [Claude Code](https://claude.ai/code)