### PR TITLE
feat(ai-dev): add per-user persistent mounts with dynamic configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,10 +164,10 @@ Per-user persistent volumes that survive workspace rebuilds and are shared acros
 
 **Toggle Parameters (order 10-13):**
 
-- **persist_vscode**: Persist VS Code Server extensions and settings at `~/.vscode-server` (default: disabled)
-- **persist_cli_config**: Persist CLI tool configuration at `~/.config` (default: disabled)
-- **persist_ssh**: Persist SSH keys and configuration at `~/.ssh` (default: disabled)
-- **persist_repos**: Persist code repositories at `~/github.com` and `~/dev.azure.com` (default: disabled)
+- **persist_vscode**: Persist VS Code Server extensions and settings at `~/.vscode-server` (default: enabled)
+- **persist_cli_config**: Persist CLI tool configuration at `~/.config` (default: enabled)
+- **persist_ssh**: Persist SSH keys and configuration at `~/.ssh` (default: enabled)
+- **persist_repos**: Persist code repositories at `~/github.com` and `~/dev.azure.com` (default: enabled)
 
 **Auto-Tied Plugin Mounts (no separate toggle):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@ Templates use two key providers:
 The `ai-dev` template follows this resource hierarchy:
 
 1. **Data Sources**: `coder_workspace`, `coder_workspace_owner` provide workspace context
-2. **Parameters**: Individual `coder_parameter` resources with `type = "bool"` for multi-select stacks and plugins
+2. **Parameters**: Individual `coder_parameter` resources with `type = "bool"` for multi-select stacks, plugins, and persistent mounts
 3. **Locals**: Dynamic script generation based on parameters using conditional concatenation
-4. **Volume**: `docker_volume` for persistent `/home/coder` storage
+4. **Volumes**: `docker_volume` for per-workspace `/home/coder` storage, plus conditional per-user persistent volumes
 5. **Agent**: `coder_agent` with startup_script containing initialization logic
 6. **Container**: `docker_container` that runs the agent init script
 7. **Apps**: `coder_app` resources exposing web services (code-server)
@@ -37,14 +37,15 @@ The template uses modular installation scripts loaded via Terraform's `file()` f
 **Scripts Directory:**
 ```
 scripts/
-├── common-deps.sh          # Shared dependencies (Node 24, gh CLI, always executed)
-├── base-ai-tools.sh        # All 6 base AI CLI tools (parallel installation)
+├── common-deps.sh                      # Shared dependencies (Node 24, gh CLI, always executed)
+├── base-ai-tools.sh                    # All 6 base AI CLI tools (parallel installation)
 ├── install-oh-my-claudecode.sh
-├── stacks/                 # Development stack installers
+├── fix-persistent-mount-permissions.sh  # Per-user volume ownership/permission fixes
+├── stacks/                              # Development stack installers
 │   ├── python-uv.sh
 │   ├── python-pip.sh
 │   └── go.sh
-└── agents/                 # AI plugin installers (optional enhancements)
+└── agents/                              # AI plugin installers (optional enhancements)
     ├── oh-my-claudecode.sh
     └── oh-my-opencode.sh
 ```
@@ -103,13 +104,14 @@ coder templates push ai-dev -d templates/ai-dev
 
 The `coder_agent.startup_script` executes in the container on startup. Critical ordering:
 
-1. **Run common-deps.sh** - Installs sudo, creates coder user, installs shared dependencies (curl, wget, git, expect, Node.js 24, gh CLI)
-2. **Run base-ai-tools.sh** - Installs all 6 AI CLI tools in parallel (claude, opencode, relentless, codex, copilot, gemini)
-3. **Run stack scripts** - Installs all selected development stacks (multiple can be enabled)
-4. **Run plugin scripts** - Installs all selected AI plugins (multiple can be enabled)
-5. **Create oh-my-claudecode setup script** (conditional) - Only if oh-my-claudecode is selected
-6. **Install code-server** - If not already present
-7. **Start code-server** - In background on port 13337
+1. **Fix persistent mount permissions** - Ensures per-user volumes are owned by `coder:coder` with correct SSH permissions
+2. **Run common-deps.sh** - Installs sudo, creates coder user, installs shared dependencies (curl, wget, git, expect, Node.js 24, gh CLI)
+3. **Run base-ai-tools.sh** - Installs all 6 AI CLI tools in parallel (claude, opencode, relentless, codex, copilot, gemini)
+4. **Run stack scripts** - Installs all selected development stacks (multiple can be enabled)
+5. **Run plugin scripts** - Installs all selected AI plugins (multiple can be enabled)
+6. **Create oh-my-claudecode setup script** (conditional) - Only if oh-my-claudecode is selected
+7. **Install code-server** - If not already present
+8. **Start code-server** - In background on port 13337
 
 Each installation step is wrapped in a subshell with `|| echo` for non-fatal error handling, allowing the container to start even if optional installations fail.
 
@@ -155,6 +157,28 @@ All 6 base AI CLI tools are automatically installed in every workspace:
 Each plugin is an individual boolean toggle parameter. Users can enable multiple plugins simultaneously:
 - **plugin_oh_my_claudecode**: Enhances Claude Code with additional configuration (default: disabled)
 - **plugin_oh_my_opencode**: Enhances OpenCode with additional features (default: disabled)
+
+### Persistent Mounts (Per-User, Mutable)
+
+Per-user persistent volumes that survive workspace rebuilds and are shared across all workspaces owned by the same user. These use `mutable = true` so they can be toggled after workspace creation.
+
+**Toggle Parameters (order 10-13):**
+
+- **persist_vscode**: Persist VS Code Server extensions and settings at `~/.vscode-server` (default: disabled)
+- **persist_cli_config**: Persist CLI tool configuration at `~/.config` (default: disabled)
+- **persist_ssh**: Persist SSH keys and configuration at `~/.ssh` (default: disabled)
+- **persist_repos**: Persist code repositories at `~/github.com` and `~/dev.azure.com` (default: disabled)
+
+**Auto-Tied Plugin Mounts (no separate toggle):**
+
+When oh-my-* plugins are enabled, their config directories get separate per-user volumes automatically to keep plugin-modified configs isolated from regular workspaces:
+
+- **Oh-My-ClaudeCode** → `~/.claude` mounted as `coder-{owner}-claude-omc`
+- **Oh-My-OpenCode** → `~/.config/opencode` mounted as `coder-{owner}-opencode-omc`
+
+**Volume Naming:** Per-user volumes use the pattern `coder-{owner_name}-{mount_name}` (vs per-workspace `coder-{workspace_id}-home`).
+
+**Permissions:** The `fix-persistent-mount-permissions.sh` script runs at startup to `chown` mount points to `coder:coder` and set correct SSH file permissions.
 
 ## Extending the Template
 
@@ -279,7 +303,9 @@ When adding new `coder_parameter` options or `coder_app` resources:
 
 ### Parameter Mutability
 
-Template parameters use `mutable = false` with `type = "bool"`, meaning they can only be set during workspace creation, not changed after deployment. This prevents runtime configuration drift. Each stack and plugin is an individual boolean toggle, allowing users to select multiple options simultaneously.
+Stack and plugin parameters use `mutable = false` with `type = "bool"`, meaning they can only be set during workspace creation. This prevents runtime configuration drift.
+
+Persistent mount parameters use `mutable = true`, allowing users to toggle persistence on/off from workspace settings after creation. Changing these triggers a workspace rebuild since the container definition changes.
 
 ### Container Count Pattern
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ A Docker-based universal AI agentic coding workspace with all major CLI tools pr
 - Ubuntu 24.04 LTS base image
 - code-server (VS Code in the browser) on port 13337
 - Persistent home directory storage
+- **Per-user persistent mounts** (mutable, shared across workspaces): VS Code settings, CLI config, SSH keys, code repos
 - **Base AI Tools** (always installed): Claude Code, OpenCode, Relentless, OpenAI Codex, GitHub Copilot, Google Gemini
 - Multi-select development stacks: Python (uv), Python (pip), Go — enable any combination
-- Multi-select AI plugins: Oh-My-ClaudeCode, Oh-My-OpenCode — enable any combination
+- Multi-select AI plugins: Oh-My-ClaudeCode, Oh-My-OpenCode — enable any combination (with auto-isolated config volumes)
 - Node.js 24 and GitHub CLI included in base
 - Pre-configured Git author/committer from Coder profile
 - Real-time resource monitoring (CPU, RAM, disk)
@@ -304,6 +305,7 @@ coder-templates/
 │       │   ├── common-deps.sh     # Shared dependencies (Node 24, gh CLI)
 │       │   ├── base-ai-tools.sh   # All 6 base AI CLI tools
 │       │   ├── install-oh-my-claudecode.sh
+│       │   ├── fix-persistent-mount-permissions.sh  # Per-user volume permissions
 │       │   ├── stacks/            # Development stack installers
 │       │   │   ├── python-uv.sh
 │       │   │   ├── python-pip.sh

--- a/templates/ai-dev/main.tf
+++ b/templates/ai-dev/main.tf
@@ -275,10 +275,11 @@ resource "coder_script" "code_server" {
     #!/bin/bash
     set -e
 
-    if ! command -v code-server >/dev/null 2>&1; then
-      echo "Installing code-server..."
-      curl -fsSL https://code-server.dev/install.sh | sh
-    fi
+    # Wait for code-server to be installed by the startup script
+    echo "Waiting for code-server installation..."
+    while ! command -v code-server >/dev/null 2>&1; do
+      sleep 5
+    done
 
     echo "Starting code-server..."
     code-server --bind-addr 0.0.0.0:13337 --auth none /home/coder >/tmp/code-server.log 2>&1 &

--- a/templates/ai-dev/main.tf
+++ b/templates/ai-dev/main.tf
@@ -271,6 +271,10 @@ resource "coder_script" "code_server" {
   display_name = "code-server"
   icon         = "/icon/code.svg"
   run_on_start = true
+  # Use exec to replace the shell with code-server, keeping it as a child of the
+  # agent process. This ensures code-server inherits the agent's mount namespace
+  # where all Docker volume submounts are visible. Without exec, backgrounding
+  # with & orphans the process to PID 1 which has a different mount view.
   script       = <<-EOT
     #!/bin/bash
     set -e
@@ -282,7 +286,7 @@ resource "coder_script" "code_server" {
     done
 
     echo "Starting code-server..."
-    code-server --bind-addr 0.0.0.0:13337 --auth none /home/coder >/tmp/code-server.log 2>&1 &
+    exec code-server --bind-addr 0.0.0.0:13337 --auth none /home/coder
   EOT
 }
 

--- a/templates/ai-dev/main.tf
+++ b/templates/ai-dev/main.tf
@@ -78,7 +78,7 @@ data "coder_parameter" "persist_vscode" {
   description  = "Persist VS Code Server extensions and settings across workspaces (per-user)"
   icon         = "/icon/code.svg"
   type         = "bool"
-  default      = "false"
+  default      = "true"
   mutable      = true
   order        = 10
 }
@@ -89,7 +89,7 @@ data "coder_parameter" "persist_cli_config" {
   description  = "Persist CLI tool configuration (~/.config) across workspaces (per-user)"
   icon         = "/icon/terminal.svg"
   type         = "bool"
-  default      = "false"
+  default      = "true"
   mutable      = true
   order        = 11
 }
@@ -100,7 +100,7 @@ data "coder_parameter" "persist_ssh" {
   description  = "Persist SSH keys and configuration across workspaces (per-user)"
   icon         = "/icon/terminal.svg"
   type         = "bool"
-  default      = "false"
+  default      = "true"
   mutable      = true
   order        = 12
 }
@@ -111,7 +111,7 @@ data "coder_parameter" "persist_repos" {
   description  = "Persist ~/github.com and ~/dev.azure.com directories across workspaces (per-user)"
   icon         = "/icon/github.svg"
   type         = "bool"
-  default      = "false"
+  default      = "true"
   mutable      = true
   order        = 13
 }

--- a/templates/ai-dev/scripts/common-deps.sh
+++ b/templates/ai-dev/scripts/common-deps.sh
@@ -44,11 +44,11 @@ if ! command -v bun >/dev/null 2>&1; then
   if ! command -v unzip >/dev/null 2>&1; then
     apt-get update && apt-get install -y unzip
   fi
-  
+
   # Run installer with BUN_INSTALL set to /usr/local
   # This avoids the 404 error caused by incorrect flag usage
   curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash || true
-  
+
   # Ensure it's symlinked to /usr/bin for scripts using #!/usr/bin/env bun
   if [ -x /usr/local/bin/bun ] && [ ! -x /usr/bin/bun ]; then
     ln -sf /usr/local/bin/bun /usr/bin/bun || true
@@ -58,4 +58,12 @@ fi
 # Final check: if bun still isn't available, print a warning (non-fatal)
 if ! command -v bun >/dev/null 2>&1; then
   echo "⚠ bun not found after install attempts - relentless may fail until bun is available"
+fi
+
+# Install code-server
+# We install it here to avoid apt lock conflicts with other startup scripts.
+# The startup logic remains in the coder_button/script to ensure volume visibility.
+if ! command -v code-server >/dev/null 2>&1; then
+  echo "Installing code-server..."
+  curl -fsSL https://code-server.dev/install.sh | sh
 fi

--- a/templates/ai-dev/scripts/fix-persistent-mount-permissions.sh
+++ b/templates/ai-dev/scripts/fix-persistent-mount-permissions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# fix-persistent-mount-permissions.sh - Fix ownership on per-user persistent volumes
+# Requires: sudo (from coder user NOPASSWD setup)
+# Runs as coder user inside startup_script
+#
+# Docker volumes are created with root ownership by default.
+# This script ensures per-user persistent mount points are owned by the coder user.
+
+# Fix ownership on any active persistent mounts
+for dir in /home/coder/.vscode-server /home/coder/.config /home/coder/.ssh \
+           /home/coder/github.com /home/coder/dev.azure.com \
+           /home/coder/.claude /home/coder/.config/opencode; do
+  if mountpoint -q "$dir" 2>/dev/null; then
+    sudo chown coder:coder "$dir"
+  fi
+done
+
+# Fix SSH permissions specifically
+if mountpoint -q /home/coder/.ssh 2>/dev/null; then
+  sudo chmod 700 /home/coder/.ssh
+  # Fix permissions on existing SSH files if present
+  sudo find /home/coder/.ssh -type f -name "id_*" ! -name "*.pub" -exec chmod 600 {} \;
+  sudo find /home/coder/.ssh -type f -name "*.pub" -exec chmod 644 {} \;
+  [ -f /home/coder/.ssh/config ] && sudo chmod 600 /home/coder/.ssh/config
+  [ -f /home/coder/.ssh/known_hosts ] && sudo chmod 644 /home/coder/.ssh/known_hosts
+fi


### PR DESCRIPTION
## Summary
- Add 4 mutable toggle parameters (persist_vscode, persist_cli_config, persist_ssh, persist_repos) for per-user persistent volumes that survive workspace rebuilds
- Volumes use per-user naming (`coder-{owner}-{name}`) so they are shared across all workspaces for the same user
- Oh-my-* plugin config directories (`~/.claude`, `~/.config/opencode`) automatically get isolated per-user volumes when the plugin is enabled
- Add permissions fix script to ensure correct ownership and SSH file permissions on persistent mounts

## Test plan
- [x] Run `terraform validate` in `templates/ai-dev/` (passed locally)
- [x] Deploy template to Coder instance with persistence toggles enabled
- [x] Verify volumes are created with `coder-{owner}-*` naming
- [x] Verify mount points are owned by `coder:coder` after startup
- [x] Verify SSH permissions are correctly set (700 dir, 600 private keys)
- [x] Verify data persists across workspace rebuild
- [x] Verify oh-my-* config volumes are created when plugins are enabled
- [x] Verify parameters are mutable (can be toggled from workspace settings)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)